### PR TITLE
Update changelog template

### DIFF
--- a/.ci/data/changelog.yml
+++ b/.ci/data/changelog.yml
@@ -9,7 +9,7 @@ unreleased:
   notice: false
   added: false
   changed:
-    - The chanagelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+    - The changelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
   deprecated: false
   removed: false
   fixed: false

--- a/.ci/data/changelog.yml
+++ b/.ci/data/changelog.yml
@@ -5,7 +5,14 @@ summary: |-
 
   The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-unreleased: false
+unreleased:
+  notice: false
+  added: false
+  changed: false
+  deprecated: false
+  removed: false
+  fixed: false
+  security: false
 releases:
   - name: v1.0.2
     tag_name: v1.0.2

--- a/.ci/data/changelog.yml
+++ b/.ci/data/changelog.yml
@@ -8,7 +8,8 @@ summary: |-
 unreleased:
   notice: false
   added: false
-  changed: false
+  changed:
+    - The chanagelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
   deprecated: false
   removed: false
   fixed: false

--- a/.ci/templates/changelog.hbs
+++ b/.ci/templates/changelog.hbs
@@ -1,7 +1,7 @@
 {{#*inline "keepachangelog"}}
 {{~#if notice}}
+> 📢 NOTICE: {{& notice}}
 
-	> 📢 NOTICE: {{& notice}}
 {{/if}}
 {{#if breaking~}}
 ### ‼️ Breaking Changes
@@ -58,9 +58,9 @@
 
 ## [Unreleased]({{plugin.uri}}/compare/{{#with (lookup changelog.releases 0)~}}{{tag_name}}{{/with}}...HEAD)
 {{#with changelog.unreleased}}
+
 {{> keepachangelog}}
 {{/with}}
-
 {{#each changelog.releases}}
 {{#if link}}
 ## [{{name}}]({{../../plugin.uri}}{{link}}) - {{date}}

--- a/.ci/templates/changelog.hbs
+++ b/.ci/templates/changelog.hbs
@@ -1,26 +1,8 @@
-# {{ changelog.title }}
-
-{{& changelog.summary}}
-
-## [Unreleased]({{plugin.uri}}/compare/{{#with (lookup changelog.releases 0)~}}{{tag_name}}{{/with}}...HEAD)
-{{#if changelog.unreleased}}
-{{#each changelog.unreleased}}
-- {{& description}}{{#if link}} ([🔗]({{link}})){{/if}}
-{{/each}}
-{{/if}}
-
-{{#each changelog.releases}}
-{{#if link}}
-## [{{name}}]({{../../plugin.uri}}{{link}}) - {{date}}
-{{else}}
-## {{name}} - {{date}}
-{{/if}}
-
+{{#*inline "keepachangelog"}}
 {{~#if notice}}
 
-> 📢 NOTICE: {{& notice}}
+	> 📢 NOTICE: {{& notice}}
 {{/if}}
-
 {{#if breaking~}}
 ### ‼️ Breaking Changes
 {{#each breaking}}
@@ -64,10 +46,27 @@
 
 {{/if}}
 {{#if security~}}
-### 🚨 Security
+	### 🚨 Security
 {{#each security}}
 - {{& this}}
 {{/each}}
-
 {{/if}}
+{{/inline}}
+# {{ changelog.title }}
+
+{{& changelog.summary}}
+
+## [Unreleased]({{plugin.uri}}/compare/{{#with (lookup changelog.releases 0)~}}{{tag_name}}{{/with}}...HEAD)
+{{#with changelog.unreleased}}
+{{> keepachangelog}}
+{{/with}}
+
+{{#each changelog.releases}}
+{{#if link}}
+## [{{name}}]({{../../plugin.uri}}{{link}}) - {{date}}
+{{else}}
+## {{name}} - {{date}}
+{{/if}}
+
+{{> keepachangelog}}
 {{/each}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/screid123/wp-plugin-template/compare/v1.0.2...HEAD)
+### 👌 Changed
+- The chanagelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
 
 ## v1.0.2 - 2021-10-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/screid123/wp-plugin-template/compare/v1.0.2...HEAD)
-### 👌 Changed
-- The chanagelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
+### 👌 Changed
+- The changelog "unreleased" now follows the same format as the "releases" and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## v1.0.2 - 2021-10-21
 


### PR DESCRIPTION
Fixes #6 
- Creates inline partial "keepachangelog" to render changelog format in changelog.hbs template
- Use partial for both `releases` and `unreleased` in changelog.hbs template
- Add keys to changelog.yml for "keepachangelog" partial format